### PR TITLE
update for macOS

### DIFF
--- a/systray.h
+++ b/systray.h
@@ -10,6 +10,7 @@ void add_or_update_menu_item(int menuId, char *title, char *tooltip, short disab
 void add_separator(int menuId);
 void add_or_update_submenu(int menuId, char *title, char *tooltip);
 void add_or_update_submenu_item(int submenuId, int menuId, char *title, char *tooltip, short disabled, short checked);
+const char *get_version();
 const char *get_git_hash();
 const char *get_user_setting(char *name);
 void set_user_setting(char *name, char *value);

--- a/systray.h
+++ b/systray.h
@@ -1,9 +1,17 @@
 extern void systray_ready();
 extern void systray_menu_item_selected(int menu_id);
+extern void systray_menu_opened();
 int nativeLoop(void);
 
-void setIcon(const char* iconBytes, int length);
-void setTitle(char* title);
-void setTooltip(char* tooltip);
-void add_or_update_menu_item(int menuId, char* title, char* tooltip, short disabled, short checked);
+void setIcon(const char *iconBytes, int length);
+void setTitle(char *title);
+void setTooltip(char *tooltip);
+void add_or_update_menu_item(int menuId, char *title, char *tooltip, short disabled, short checked);
+void add_separator(int menuId);
+void add_or_update_submenu(int menuId, char *title, char *tooltip);
+void add_or_update_submenu_item(int submenuId, int menuId, char *title, char *tooltip, short disabled, short checked);
+const char *get_git_hash();
+const char *get_user_setting(char *name);
+void set_user_setting(char *name, char *value);
+void hang();
 void quit();

--- a/systray_darwin.m
+++ b/systray_darwin.m
@@ -3,93 +3,123 @@
 
 @interface MenuItem : NSObject
 {
-  @public
-    NSNumber* menuId;
-    NSString* title;
-    NSString* tooltip;
-    short disabled;
-    short checked;
+@public
+  NSNumber *menuId;
+  NSNumber *submenuId;
+  NSString *title;
+  NSString *tooltip;
+  short disabled;
+  short checked;
+  short separator;
+  short submenu;
+
 }
--(id) initWithId: (int)theMenuId
-       withTitle: (const char*)theTitle
-     withTooltip: (const char*)theTooltip
-    withDisabled: (short)theDisabled
-     withChecked: (short)theChecked;
-     @end
-     @implementation MenuItem
-     -(id) initWithId: (int)theMenuId
-            withTitle: (const char*)theTitle
-          withTooltip: (const char*)theTooltip
-         withDisabled: (short)theDisabled
-          withChecked: (short)theChecked
+- (id)initWithId:(int)theMenuId
+       withTitle:(const char *)theTitle
+     withTooltip:(const char *)theTooltip
+    withDisabled:(short)theDisabled
+     withChecked:(short)theChecked;
+
+- (id)initSeparatorWithId:(int)theMenuId;
+
+- (id)initSubmenuWithId:(int)theMenuId
+              withTitle:(const char *)theTitle
+            withTooltip:(const char *)theTooltip;
+@end
+@implementation MenuItem
+
+- (id)initWithId:(int)theMenuId
+       withTitle:(const char *)theTitle
+     withTooltip:(const char *)theTooltip
+    withDisabled:(short)theDisabled
+     withChecked:(short)theChecked
 {
   menuId = [NSNumber numberWithInt:theMenuId];
+  submenuId = nil;
   title = [[NSString alloc] initWithCString:theTitle
                                    encoding:NSUTF8StringEncoding];
   tooltip = [[NSString alloc] initWithCString:theTooltip
                                      encoding:NSUTF8StringEncoding];
   disabled = theDisabled;
   checked = theChecked;
+  separator = 0;
+  submenu = 0;
   return self;
 }
+
+- (id)initSeparatorWithId:(int)theMenuId {
+  menuId = [NSNumber numberWithInt:theMenuId];
+  submenuId = nil;
+  title = nil;
+  tooltip = nil;
+  disabled = 0;
+  checked = 0;
+  separator = 1;
+  submenu = 0;
+  return self;
+}
+
+- (id)initSubmenuWithId:(int)theMenuId
+              withTitle:(const char *)theTitle
+            withTooltip:(const char *)theTooltip
+{
+  menuId = [NSNumber numberWithInt:theMenuId];
+  submenuId = nil;
+  title = [[NSString alloc] initWithCString:theTitle
+                                   encoding:NSUTF8StringEncoding];
+  tooltip = [[NSString alloc] initWithCString:theTooltip
+                                     encoding:NSUTF8StringEncoding];
+  disabled = 0;
+  checked = 0;
+  separator = 0;
+  submenu = 1;
+  return self;
+}
+
 @end
 
-@interface AppDelegate: NSObject <NSApplicationDelegate>
-  - (void) add_or_update_menu_item:(MenuItem*) item;
-  - (IBAction)menuHandler:(id)sender;
-  @property (assign) IBOutlet NSWindow *window;
-  @end
+@interface MenuItemRegistry : NSObject <NSMenuDelegate>
+@property (strong) NSMenu *menu;
+@property (strong) NSMutableDictionary *submenus;
+@property (strong, nonatomic) NSStatusItem *statusItem;
+- (void)addOrUpdateMenuItem:(MenuItem *)item;
+- (void)addSeparator:(MenuItem *)item;
+- (void)addOrUpdateSubmenu:(MenuItem *)item;
+- (void)addOrUpdateSubmenuItem:(MenuItem *)item;
+- (IBAction)menuHandler:(id)sender;
+- (void)hang;
+- (void)quit;
++ (MenuItemRegistry *)sharedRegistry;
+@end
 
-  @implementation AppDelegate
-{
-  NSStatusItem *statusItem;
-  NSMenu *menu;
-  NSCondition* cond;
-}
+@implementation MenuItemRegistry
 
-@synthesize window = _window;
+static MenuItemRegistry *sharedRegistry = nil;
 
-- (void)applicationDidFinishLaunching:(NSNotification *)aNotification
-{
-  self->statusItem = [[NSStatusBar systemStatusBar] statusItemWithLength:NSVariableStatusItemLength];
-  self->menu = [[NSMenu alloc] init];
-  [self->menu setAutoenablesItems: FALSE];
-  [self->statusItem setMenu:self->menu];
+- (id)init {
+  self = [super init];
+  self.menu = [[NSMenu alloc] init];
+  [self.menu setAutoenablesItems:FALSE];
+  [self.menu setDelegate:self];
+  self.submenus = [[NSMutableDictionary alloc] init];
+  self.statusItem = [[NSStatusBar systemStatusBar] statusItemWithLength:NSVariableStatusItemLength];
+  [self.statusItem setMenu:self.menu];
   systray_ready();
+  return self;
 }
 
-- (void)setIcon:(NSImage *)image {
-  [statusItem setImage:image];
-}
-
-- (void)setTitle:(NSString *)title {
-  [statusItem setTitle:title];
-}
-
-- (void)setTooltip:(NSString *)tooltip {
-  [statusItem setToolTip:tooltip];
-}
-
-- (IBAction)menuHandler:(id)sender
-{
-  NSNumber* menuId = [sender representedObject];
-  systray_menu_item_selected(menuId.intValue);
-}
-
-- (void) add_or_update_menu_item:(MenuItem*) item
-{
+- (void)addOrUpdateMenuItem:(MenuItem*)item {
   NSMenuItem* menuItem;
-  int existedMenuIndex = [menu indexOfItemWithRepresentedObject: item->menuId];
+  int existedMenuIndex = [self.menu indexOfItemWithRepresentedObject:item->menuId];
   if (existedMenuIndex == -1) {
-    menuItem = [menu addItemWithTitle:item->title action:@selector(menuHandler:) keyEquivalent:@""];
+    menuItem = [self.menu addItemWithTitle:item->title action:@selector(menuHandler:) keyEquivalent:@""];
     [menuItem setTarget:self];
-    [menuItem setRepresentedObject: item->menuId];
-
-  }
-  else {
-    menuItem = [menu itemAtIndex: existedMenuIndex];
+    [menuItem setRepresentedObject:item->menuId];
+  } else {
+    menuItem = [self.menu itemAtIndex:existedMenuIndex];
     [menuItem setTitle:item->title];
   }
+
   [menuItem setToolTip:item->tooltip];
   if (item->disabled == 1) {
     [menuItem setEnabled:FALSE];
@@ -103,52 +133,197 @@
   }
 }
 
-- (void) quit
-{
-  [[NSStatusBar systemStatusBar] removeStatusItem: statusItem];
+- (void)addSeparator:(MenuItem *)item {
+  NSMenuItem* menuItem;
+  int existedMenuIndex = [self.menu indexOfItemWithRepresentedObject:item->menuId];
+  if (existedMenuIndex == -1) {
+    menuItem = [NSMenuItem separatorItem];
+    [self.menu addItem:menuItem];
+    [menuItem setTarget:self];
+    [menuItem setRepresentedObject:item->menuId];
+  }
+}
+
+- (void)addOrUpdateSubmenu:(MenuItem *)item {
+  NSMenuItem* menuItem;
+  int existedMenuIndex = [self.menu indexOfItemWithRepresentedObject:item->menuId];
+  if (existedMenuIndex == -1) {
+    menuItem = [self.menu addItemWithTitle:item->title action:nil keyEquivalent:@""];
+    [menuItem setTarget:self];
+    [menuItem setRepresentedObject:item->menuId];
+    NSMenu *submenu = [[NSMenu alloc] initWithTitle:item->title];
+    self.submenus[item->menuId] = submenu;
+    [self.menu setSubmenu:submenu forItem:menuItem];
+  }
+}
+
+- (void)addOrUpdateSubmenuItem:(MenuItem *)item {
+  NSMenuItem* menuItem;
+  NSMenu *submenu = self.submenus[item->submenuId];
+  int existedMenuIndex = [submenu indexOfItemWithRepresentedObject:item->menuId];
+  if (existedMenuIndex == -1) {
+    menuItem = [submenu addItemWithTitle:item->title action:@selector(menuHandler:) keyEquivalent:@""];
+    [menuItem setTarget:self];
+    [menuItem setRepresentedObject:item->menuId];
+  } else {
+    menuItem = [submenu itemAtIndex:existedMenuIndex];
+    [menuItem setTitle:item->title];
+  }
+
+  [menuItem setToolTip:item->tooltip];
+  if (item->disabled == 1) {
+    [menuItem setEnabled:FALSE];
+  } else {
+    [menuItem setEnabled:TRUE];
+  }
+  if (item->checked == 1) {
+    [menuItem setState:NSOnState];
+  } else {
+    [menuItem setState:NSOffState];
+  }
+}
+
+- (IBAction)menuHandler:(id)sender {
+  NSNumber* menuId = [sender representedObject];
+  systray_menu_item_selected(menuId.intValue);
+}
+
+- (void)setIcon:(NSImage *)image {
+  [self.statusItem setImage:image];
+}
+
+- (void)setTitle:(NSString *)title {
+  [self.statusItem setTitle:title];
+}
+
+- (void)setTooltip:(NSString *)tooltip {
+  [self.statusItem setToolTip:tooltip];
+}
+
+- (void)hang {
+  sleep(100000000);
+}
+
+- (void)quit {
+  [[NSStatusBar systemStatusBar] removeStatusItem:self.statusItem];
+  [NSApp terminate:[[NSApplication sharedApplication] delegate]];
+}
+
+- (void)menuWillOpen:(NSMenu *)menu {
+  systray_menu_opened();
+}
+
++ (MenuItemRegistry *)sharedRegistry {
+  static dispatch_once_t pred;
+  static id sharedRegistry = nil;
+  dispatch_once(&pred, ^{
+    sharedRegistry = [[[self class] alloc] init];
+  });
+  return sharedRegistry;
 }
 
 @end
 
+
 int nativeLoop(void) {
-  AppDelegate *delegate = [[AppDelegate alloc] init];
-  [[NSApplication sharedApplication] setDelegate:delegate];
-  [NSApp run];
-  return EXIT_SUCCESS;
+  [MenuItemRegistry
+    performSelectorOnMainThread:@selector(sharedRegistry)
+                     withObject:nil
+                  waitUntilDone:YES];
+  return 0;
 }
 
 void runInMainThread(SEL method, id object) {
-  [(AppDelegate*)[NSApp delegate]
+  [[MenuItemRegistry sharedRegistry]
     performSelectorOnMainThread:method
                      withObject:object
-                  waitUntilDone: YES];
+                  waitUntilDone:YES];
 }
 
-void setIcon(const char* iconBytes, int length) {
-  NSData* buffer = [NSData dataWithBytes: iconBytes length:length];
+void setIcon(const char *iconBytes, int length) {
+  NSData *buffer = [NSData dataWithBytes:iconBytes length:length];
   NSImage *image = [[NSImage alloc] initWithData:buffer];
   runInMainThread(@selector(setIcon:), (id)image);
 }
 
-void setTitle(char* ctitle) {
-  NSString* title = [[NSString alloc] initWithCString:ctitle
+void setTitle(char *ctitle) {
+  NSString *title = [[NSString alloc] initWithCString:ctitle
                                              encoding:NSUTF8StringEncoding];
   free(ctitle);
   runInMainThread(@selector(setTitle:), (id)title);
 }
 
-void setTooltip(char* ctooltip) {
-  NSString* tooltip = [[NSString alloc] initWithCString:ctooltip
+void setTooltip(char *ctooltip) {
+  NSString *tooltip = [[NSString alloc] initWithCString:ctooltip
                                                encoding:NSUTF8StringEncoding];
   free(ctooltip);
   runInMainThread(@selector(setTooltip:), (id)tooltip);
 }
 
-void add_or_update_menu_item(int menuId, char* title, char* tooltip, short disabled, short checked) {
-  MenuItem* item = [[MenuItem alloc] initWithId: menuId withTitle: title withTooltip: tooltip withDisabled: disabled withChecked: checked];
+void add_or_update_menu_item(int menuId, char *title, char *tooltip, short disabled, short checked) {
+  MenuItem *item = [[MenuItem alloc]
+                     initWithId:menuId
+                      withTitle:title
+                     withTooltip:tooltip
+                     withDisabled:disabled
+                     withChecked:checked];
   free(title);
   free(tooltip);
-  runInMainThread(@selector(add_or_update_menu_item:), (id)item);
+  runInMainThread(@selector(addOrUpdateMenuItem:), (id)item);
+}
+
+void add_separator(int menuId) {
+  MenuItem *item = [[MenuItem alloc] initSeparatorWithId:menuId];
+  runInMainThread(@selector(addSeparator:), (id)item);
+}
+
+void add_or_update_submenu(int menuId, char *title, char *tooltip) {
+  MenuItem *item = [[MenuItem alloc]
+                     initSubmenuWithId:menuId
+                             withTitle:title
+                           withTooltip:tooltip];
+  free(title);
+  free(tooltip);
+  runInMainThread(@selector(addOrUpdateSubmenu:), (id)item);
+}
+
+void add_or_update_submenu_item(int submenuId, int menuId, char *title, char *tooltip, short disabled, short checked) {
+  MenuItem *item = [[MenuItem alloc]
+                     initWithId:menuId
+                      withTitle:title
+                     withTooltip:tooltip
+                     withDisabled:disabled
+                     withChecked:checked];
+  item->submenuId = [NSNumber numberWithInt:submenuId];
+  free(title);
+  free(tooltip);
+  runInMainThread(@selector(addOrUpdateSubmenuItem:), (id)item);
+}
+
+const char *get_git_hash() {
+  NSString *path = [[NSBundle mainBundle] pathForResource:@"Git" ofType:@"plist"];
+  NSDictionary *gitPlist = [[NSDictionary alloc] initWithContentsOfFile:path];
+  NSString *hash = [gitPlist objectForKey:@"GitHash"];
+  return [hash UTF8String];
+}
+
+const char *get_user_setting(char *name) {
+  NSUserDefaults *prefs = [NSUserDefaults standardUserDefaults];
+  NSString *setting = [prefs stringForKey:[[NSString alloc] initWithUTF8String:name]];
+  free(name);
+  return [setting UTF8String];
+}
+
+void set_user_setting(char *name, char *value) {
+  NSString *nameStr = [[NSString alloc] initWithUTF8String:name];
+  NSString *valueStr = [[NSString alloc] initWithUTF8String:value];
+  free(name);
+  free(value);
+  [[NSUserDefaults standardUserDefaults] setObject:valueStr forKey:nameStr];
+}
+
+void hang() {
+  runInMainThread(@selector(hang), nil);
 }
 
 void quit() {

--- a/systray_darwin.m
+++ b/systray_darwin.m
@@ -300,6 +300,11 @@ void add_or_update_submenu_item(int submenuId, int menuId, char *title, char *to
   runInMainThread(@selector(addOrUpdateSubmenuItem:), (id)item);
 }
 
+const char *get_version() {
+  NSString *version = [[[NSBundle mainBundle] infoDictionary] objectForKey:@"CFBundleVersion"];
+  return [version UTF8String];
+}
+
 const char *get_git_hash() {
   NSString *path = [[NSBundle mainBundle] pathForResource:@"Git" ofType:@"plist"];
   NSDictionary *gitPlist = [[NSDictionary alloc] initWithContentsOfFile:path];

--- a/systray_nonwindows.go
+++ b/systray_nonwindows.go
@@ -42,6 +42,12 @@ func SetTooltip(tooltip string) {
 	C.setTooltip(C.CString(tooltip))
 }
 
+// GetVersion returns the version number of the calling app
+func GetVersion() string {
+	cstr := C.get_version()
+	return C.GoString(cstr)
+}
+
 // GetGitHash returns the git hash of the current project
 func GetGitHash() string {
 	cstr := C.get_git_hash()

--- a/systray_nonwindows.go
+++ b/systray_nonwindows.go
@@ -42,6 +42,28 @@ func SetTooltip(tooltip string) {
 	C.setTooltip(C.CString(tooltip))
 }
 
+// GetGitHash returns the git hash of the current project
+func GetGitHash() string {
+	cstr := C.get_git_hash()
+	return C.GoString(cstr)
+}
+
+// GetUserSetting returns the string value of a user setting
+func GetUserSetting(name string) string {
+	cstr := C.get_user_setting(C.CString(name))
+	return C.GoString(cstr)
+}
+
+// SetUserSetting sets the string value of a user setting
+func SetUserSetting(name, value string) {
+	C.set_user_setting(C.CString(name), C.CString(value))
+}
+
+// Hang sleeps for a indefinite amount of time
+func Hang() {
+	C.hang()
+}
+
 func addOrUpdateMenuItem(item *MenuItem) {
 	var disabled C.short
 	if item.disabled {
@@ -60,6 +82,37 @@ func addOrUpdateMenuItem(item *MenuItem) {
 	)
 }
 
+func addSeparator(item *MenuItem) {
+	C.add_separator(C.int(item.id))
+}
+
+func addOrUpdateSubmenu(item *MenuItem) {
+	C.add_or_update_submenu(
+		C.int(item.id),
+		C.CString(item.title),
+		C.CString(item.tooltip),
+	)
+}
+
+func addOrUpdateSubmenuItem(item *MenuItem) {
+	var disabled C.short
+	if item.disabled {
+		disabled = 1
+	}
+	var checked C.short
+	if item.checked {
+		checked = 1
+	}
+	C.add_or_update_submenu_item(
+		C.int(item.submenuId),
+		C.int(item.id),
+		C.CString(item.title),
+		C.CString(item.tooltip),
+		disabled,
+		checked,
+	)
+}
+
 //export systray_ready
 func systray_ready() {
 	systrayReady()
@@ -68,4 +121,9 @@ func systray_ready() {
 //export systray_menu_item_selected
 func systray_menu_item_selected(cID C.int) {
 	systrayMenuItemSelected(int32(cID))
+}
+
+//export systray_menu_opened
+func systray_menu_opened() {
+	menuOpened()
 }


### PR DESCRIPTION
* Changes this library to be used in a parent macOS application vs being a standalone app
* Adds functionality to add visual separators and submenus
* Adds helper functions to handle application specific data (user settings, git info, etc)
* Adds ability to register a handler when the menu is opened e.g. for metrics
* Modifies `onReady` / the `Run` loop to accept an arbitrary object